### PR TITLE
Add the react-native-reanimated babel plugin

### DIFF
--- a/GetstreamIntegrationReproduce/babel.config.js
+++ b/GetstreamIntegrationReproduce/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  plugins: ['react-native-reanimated/plugin'],
 };


### PR DESCRIPTION
A couple of things were missing from setting the chat up:

1. The babel plugin for `react-native-reanimated` has to be set up for the app to build. See the [installation documentation for reanimated](https://docs.swmansion.com/react-native-reanimated/docs/next/fundamentals/installation)
2. The channel is set up in the useEffect hook right after connecting the user. That way, we can know that the channel is loaded before rendering it. 

One thing to note is that there's currently an error thrown because the user doesn't have an image (is what it seems like), which I'm adding to our backlog to look into on our end. For the time being, that should be resolved if you add an image for the user being added.